### PR TITLE
Remove __all__ in __init__

### DIFF
--- a/fastapi_plugins/__init__.py
+++ b/fastapi_plugins/__init__.py
@@ -33,7 +33,6 @@ from .version import VERSION
 #     from .scheduler import *  # noqa F401 F403
 
 
-__all__ = []
 __author__ = 'madkote <madkote(at)bluewin.ch>'
 __version__ = '.'.join(str(x) for x in VERSION)
 __copyright__ = 'Copyright 2019, madkote'


### PR DESCRIPTION
Hi, I noticed this project uses `__all__` for most of its modules. However, in `fastapi_plugins/__init__.py` I see `__all__ = []` which causes my editor to warn with things like `'RedisSettings' is not declared in __all__`. I decided to simply remove `__all__` from there since it is optional. Alternatively, I could combine `__all__` from each of the imported modules.

What do you think?