### PR TITLE
fix: Update control endpoint `examples` to use correct type currently breaking openapi integration for these endpoints

### DIFF
--- a/fastapi_plugins/control.py
+++ b/fastapi_plugins/control.py
@@ -31,7 +31,6 @@ __all__ = [
     'ControlPlugin', 'control_plugin', 'depends_control', 'TControlPlugin'
 ]
 
-
 DEFAULT_CONTROL_ROUTER_PREFIX = 'control'
 DEFAULT_CONTROL_VERSION = '0.0.1'
 
@@ -51,7 +50,9 @@ class ControlEnviron(ControlBaseModel):
     environ: typing.Dict = pydantic.Field(
         ...,
         title='Environment',
-        examples=[dict(var1='variable1', var2='variable2')]
+        examples=[
+            dict(var1='variable1', var2='variable2')
+        ]
     )
 
 
@@ -98,16 +99,18 @@ class ControlHealthError(ControlBaseModel):
     detail: ControlHealth = pydantic.Field(
         ...,
         title='Health error',
-        examples=[ControlHealth(
-            status=False,
-            checks=[
-                ControlHealthCheck(
-                    name='Redis',
-                    status=False,
-                    details=dict(error='Some error')
-                )
-            ]
-        )]
+        examples=[
+            ControlHealth(
+                status=False,
+                checks=[
+                    ControlHealthCheck(
+                        name='Redis',
+                        status=False,
+                        details=dict(error='Some error')
+                    )
+                ]
+            )
+        ]
     )
 
 


### PR DESCRIPTION
Hi,

We currently have an issue with the control endpoints provided by fastapi-plugins where our openapi json fails to generate when we include the endpoints.

It looks like this is caused by a type mismatch in the library introduced when updating from version 1 -> 2 of pydantic where the field name changed from `example` to `examples`. This renamed field expects a `list` type for all examples.
Example of the error message:
```
components.schemas.ControlHeartBeat.Schema.properties.is_alive.bool
  Input should be a valid boolean [type=bool_type, input_value={'examples': True, 'title...lag', 'type': 'boolean'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.7/v/bool_type
```

The fix seems straightforward just adding `[]` to the examples provided. I've tested this locally and it seems to work fine.

I'm not sure how to contribute to the project so please feel free inform if I've missed anything. I managed to run some but not all of the tests locally so would appreciate some input here just to make sure there are no regressions.

Thanks,
James